### PR TITLE
move code listing to array

### DIFF
--- a/fpt-egui/src/main.rs
+++ b/fpt-egui/src/main.rs
@@ -313,9 +313,10 @@ impl FPT {
             });
         });
         // TODO: scroll into line of current pc (need to find index)
+        // TODO: differentiate current pc
         ui.collapsing("Code", |ui| {
             let mem = self.gb.bus().memory();
-            let code_flat: Vec<&String> = mem.code().iter().flatten().collect();
+            let code_flat: Vec<&String> = mem.code_listing().iter().flatten().collect();
             ScrollArea::vertical().show_rows(
                 ui,
                 ui.text_style_height(&egui::TextStyle::Body),

--- a/fpt/src/lr35902.rs
+++ b/fpt/src/lr35902.rs
@@ -596,7 +596,7 @@ impl LR35902 {
         if self.inst_cycle_count() < inst.cycles {
             return;
         }
-        self.update_code(inst);
+        self.update_code_listing(inst);
         if self.imenc {
             self.set_interrupt_master_enable(true);
             self.imenc = false;
@@ -618,8 +618,8 @@ impl LR35902 {
         self.set_inst_cycle_count(0);
     }
 
-    fn update_code(&mut self, inst: Instruction) {
-        if self.mem.memory().code()[self.pc() as usize].is_some() {
+    fn update_code_listing(&mut self, inst: Instruction) {
+        if self.mem.memory().code_listing()[self.pc() as usize].is_some() {
             return;
         }
         let result: Vec<String> = (1..inst.size)
@@ -633,7 +633,7 @@ impl LR35902 {
             if result.is_empty() { "" } else { " " },
             result.join(" ")
         );
-        self.mem.memory_mut().set_code(self.pc() as usize, str);
+        self.mem.memory_mut().set_code_listing_at(self.pc(), str);
     }
 
     /// Run one complete instruction - NOT a machine cycle (4 t-cycles)

--- a/fpt/src/memory.rs
+++ b/fpt/src/memory.rs
@@ -204,7 +204,7 @@ pub struct Memory {
     mem: [u8; 65536],
     cartridge: Vec<u8>,
     bootrom: &'static [u8; 256],
-    code: [Option<String>; 0xffff + 1],
+    code_listing: [Option<String>; 0xffff + 1],
 }
 
 impl PartialEq for Memory {
@@ -226,7 +226,7 @@ impl Memory {
             mem: [0; 65536],
             cartridge: Vec::new(),
             bootrom: include_bytes!("../dmg0.bin"),
-            code: [ARRAY_REPEAT_VALUE; 0xffff + 1],
+            code_listing: [ARRAY_REPEAT_VALUE; 0xffff + 1],
         }
     }
 
@@ -242,12 +242,12 @@ impl Memory {
         &mut self.mem[range]
     }
 
-    pub fn code(&self) -> &[Option<String>; 0xffff + 1] {
-        &self.code
+    pub fn code_listing(&self) -> &[Option<String>; 0xffff + 1] {
+        &self.code_listing
     }
 
-    pub fn set_code(&mut self, i: usize, v: String) {
-        self.code[i] = Some(v);
+    pub fn set_code_listing_at(&mut self, pc: u16, v: String) {
+        self.code_listing[pc as usize] = Some(v);
     }
 }
 
@@ -272,7 +272,7 @@ impl Bus {
         let bootrom = self.memory().bootrom;
         self.clone_from_slice(map::BOOTROM, bootrom);
         for i in map::BOOTROM {
-            self.memory_mut().code[i] = None;
+            self.memory_mut().code_listing[i] = None;
         }
     }
 
@@ -280,7 +280,7 @@ impl Bus {
         let cartridge = self.memory_mut().cartridge[map::BOOTROM].to_vec();
         self.clone_from_slice(map::BOOTROM, &cartridge);
         for i in map::BOOTROM {
-            self.memory_mut().code[i] = None;
+            self.memory_mut().code_listing[i] = None;
         }
     }
 

--- a/fpt/src/memory.rs
+++ b/fpt/src/memory.rs
@@ -271,9 +271,7 @@ impl Bus {
     pub fn load_bootrom(&mut self) {
         let bootrom = self.memory().bootrom;
         self.clone_from_slice(map::BOOTROM, bootrom);
-        for i in map::BOOTROM {
-            self.memory_mut().code_listing[i] = None;
-        }
+        self.memory_mut().code_listing[map::BOOTROM].fill(None)
     }
 
     pub fn unload_bootrom(&mut self) {


### PR DESCRIPTION
Move the code listing to an array and clear certain regions of it when we know the code changes - bootrom unloading, rom switching, etc.

_This assumes self modifying code is not a thing_

@diogotito what do you think of this? we should probably go with your idea of not duplicating this `code` array. Our memory should be an array of structs that may contain the code string. I was thinking something like:
```
struct MemoryByte {
    byte: u8,
    code: Option<String>
}

pub struct Memory {
    mem: [MemoryByte; 65536],
    cartridge: Vec<u8>,
    bootrom: &'static [u8; 256]
}
```
WDYT?