### PR TITLE
Initialize CPU and hardware registers to post-bootrom values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -735,6 +735,7 @@ dependencies = [
 name = "fpt"
 version = "0.1.0"
 dependencies = [
+ "regex",
  "rstest",
 ]
 

--- a/fpt-cli/src/main.rs
+++ b/fpt-cli/src/main.rs
@@ -20,18 +20,23 @@ struct Cli {
     command: Commands,
 }
 
-#[derive(Debug, Args)]
+#[derive(Clone, Debug, Args)]
 struct GameboyConfig {
+    /// Apply known CPU and hardware register values of a well-known bootrom when it
+    /// hands off the execution to the cartridge's code. This skips emulating a bootrom.
     #[arg(short, long)]
     fake_bootrom: Option<BootromToFake>,
 }
 
 impl GameboyConfig {
-    /// Build a Gameboy following this configuration. Consumes self.
+    /// Build a `Gameboy` following this configuration. Consumes self.
     pub fn build_gameboy(self: Self) -> Gameboy {
         let mut gameboy = Gameboy::new();
-        if let Some(BootromToFake::DMG0) = self.fake_bootrom {
-            gameboy.simulate_dmg0_bootrom_handoff_state();
+        match self.fake_bootrom {
+            Some(BootromToFake::DMG0) => {
+                gameboy.simulate_dmg0_bootrom_handoff_state();
+            }
+            None => {}
         }
         gameboy
     }

--- a/fpt-cli/src/main.rs
+++ b/fpt-cli/src/main.rs
@@ -3,7 +3,7 @@
 
 use std::fs;
 
-use clap::{Args, Parser, Subcommand};
+use clap::{Args, Parser, Subcommand, ValueEnum};
 use debugger::DebuggerTextInterface;
 use fpt::Gameboy;
 use rustyline::error::ReadlineError;
@@ -14,8 +14,32 @@ pub mod debugger;
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 struct Cli {
+    #[command(flatten)]
+    gameboy_config: GameboyConfig,
     #[command(subcommand)]
     command: Commands,
+}
+
+#[derive(Debug, Args)]
+struct GameboyConfig {
+    #[arg(short, long)]
+    fake_bootrom: Option<BootromToFake>,
+}
+
+impl GameboyConfig {
+    /// Build a Gameboy following this configuration. Consumes self.
+    pub fn build_gameboy(self: Self) -> Gameboy {
+        let mut gameboy = Gameboy::new();
+        if let Some(BootromToFake::DMG0) = self.fake_bootrom {
+            gameboy.simulate_dmg0_bootrom_handoff_state();
+        }
+        gameboy
+    }
+}
+
+#[derive(ValueEnum, Debug, Clone, PartialEq)]
+enum BootromToFake {
+    DMG0,
 }
 
 #[derive(Subcommand, Debug)]
@@ -93,9 +117,10 @@ fn dump(args: Dump) -> Result<()> {
     }
 }
 
-fn run(args: Run) -> Result<()> {
-    let mut gameboy = Gameboy::new();
-    let rom = fs::read(args.rom).unwrap();
+fn run(gb_config: GameboyConfig, args: Run) -> Result<()> {
+    let mut gameboy = gb_config.build_gameboy();
+
+    let rom = fs::read(args.rom)?;
     gameboy.load_rom(&rom);
     loop {
         if args.debug.unwrap_or(false) {
@@ -107,9 +132,11 @@ fn run(args: Run) -> Result<()> {
 
 fn main() -> Result<()> {
     let args = Cli::parse();
+    let gb_config = args.gameboy_config;
+
     match args.command {
         Commands::Debug {} => debug(),
         Commands::Dump(args) => dump(args),
-        Commands::Run(args) => run(args),
+        Commands::Run(args) => run(gb_config, args),
     }
 }

--- a/fpt/src/lib.rs
+++ b/fpt/src/lib.rs
@@ -31,6 +31,61 @@ impl Gameboy {
         }
     }
 
+    /// Sets CPU and hardware registers to the values found in the DMG0 column in the tables at
+    /// https://gbdev.io/pandocs/Power_Up_Sequence.html#console-state-after-boot-rom-hand-off
+    pub fn simulate_dmg0_bootrom_handoff_state(&mut self) {
+        // CPU registers
+        self.cpu.set_af(0x0100);
+        self.cpu.set_bc(0xff13);
+        self.cpu.set_de(0x00c1);
+        self.cpu.set_hl(0x8403);
+        self.cpu.set_sp(0xfffe);
+        self.cpu.set_pc(0x100); // This effectively skips the bootrom
+
+        // HW registers
+        self.bus.write(0xFF00, 0xCF); // P1
+        self.bus.write(0xFF01, 0x00); // SB
+        self.bus.write(0xFF02, 0x7E); // SC
+        self.bus.write(0xFF04, 0x18); // DIV
+        self.bus.write(0xFF05, 0x00); // TIMA
+        self.bus.write(0xFF06, 0x00); // TMA
+        self.bus.write(0xFF07, 0xF8); // TAC
+        self.bus.write(0xFF0F, 0xE1); // IF
+        self.bus.write(0xFF10, 0x80); // NR10
+        self.bus.write(0xFF11, 0xBF); // NR11
+        self.bus.write(0xFF12, 0xF3); // NR12
+        self.bus.write(0xFF13, 0xFF); // NR13
+        self.bus.write(0xFF14, 0xBF); // NR14
+        self.bus.write(0xFF16, 0x3F); // NR21
+        self.bus.write(0xFF17, 0x00); // NR22
+        self.bus.write(0xFF18, 0xFF); // NR23
+        self.bus.write(0xFF19, 0xBF); // NR24
+        self.bus.write(0xFF1A, 0x7F); // NR30
+        self.bus.write(0xFF1B, 0xFF); // NR31
+        self.bus.write(0xFF1C, 0x9F); // NR32
+        self.bus.write(0xFF1D, 0xFF); // NR33
+        self.bus.write(0xFF1E, 0xBF); // NR34
+        self.bus.write(0xFF20, 0xFF); // NR41
+        self.bus.write(0xFF21, 0x00); // NR42
+        self.bus.write(0xFF22, 0x00); // NR43
+        self.bus.write(0xFF23, 0xBF); // NR44
+        self.bus.write(0xFF24, 0x77); // NR50
+        self.bus.write(0xFF25, 0xF3); // NR51
+        self.bus.write(0xFF26, 0xF1); // NR52
+        self.bus.write(0xFF40, 0x91); // LCDC
+        self.bus.write(0xFF41, 0x81); // STAT
+        self.bus.write(0xFF42, 0x00); // SCY
+        self.bus.write(0xFF43, 0x00); // SCX
+        self.bus.write(0xFF44, 0x91); // LY
+        self.bus.write(0xFF45, 0x00); // LYC
+        self.bus.write(0xFF46, 0xFF); // DMA
+        self.bus.write(0xFF47, 0xFC); // BGP
+        self.bus.write(0xFF48, 0x00); // OBP0
+        self.bus.write(0xFF49, 0x00); // OBP1
+        self.bus.write(0xFF4A, 0x00); // WY
+        self.bus.write(0xFF4B, 0x00); // WX
+    }
+
     pub fn load_rom(&mut self, rom: &[u8]) {
         self.bus.load_cartridge(rom);
     }

--- a/fpt/src/lr35902.rs
+++ b/fpt/src/lr35902.rs
@@ -54,12 +54,12 @@ impl DebugInterface for LR35902 {
 impl LR35902 {
     pub fn new(memory: Bus) -> Self {
         Self {
-            af: 0x0100,
-            bc: 0xff13,
-            de: 0x00c1,
-            hl: 0x8403,
-            sp: 0xfffe,
-            pc: 0x100,
+            af: 0,
+            bc: 0,
+            de: 0,
+            hl: 0,
+            sp: 0,
+            pc: 0,
             ime: false,
             imenc: false,
             prefix_cb: false,


### PR DESCRIPTION
I used the values found at
<https://gbdev.io/pandocs/Power_Up_Sequence.html#console-state-after-boot-rom-hand-off>.

I also moved these values from the `LR35902` constructor to the `fpt` library crate root module, in a `Gameboy` method, that is optionally called from `fpt-cli` by passing `--fake-bootrom dmg0` as the first argument in the CLI (maybe this should be the default, instead of fully emulating the bootrom?)

I'm open to other ways of modeling other bootrom values, or going with a simpler approach (maybe it's too early for a `struct GameboyConfig` in `fpt-cli`?).