### PR TITLE
Fix BIT instructions zero flag behavior

### DIFF
--- a/fpt/src/lr35902.rs
+++ b/fpt/src/lr35902.rs
@@ -607,9 +607,7 @@ impl LR35902 {
     }
 
     fn bit<const INDEX: u8>(&mut self, x: u8) {
-        if !bw::test_bit8::<INDEX>(x) {
-            self.set_z_flag(true);
-        }
+        self.set_z_flag(!bw::test_bit8::<INDEX>(x));
         self.set_n_flag(false);
         self.set_h_flag(true);
     }

--- a/fpt/tests/lr35902.rs
+++ b/fpt/tests/lr35902.rs
@@ -1435,7 +1435,9 @@ fn test_rot_reg_addr(
 
 #[rstest]
 #[case::not_zero(0x1, 0b0001, 0b0011)]
+#[case::not_zero(0x1, 0b1001, 0b0011)]
 #[case::zero(0x0, 0b0000, 0b1010)]
+#[case::zero(0x0, 0b1000, 0b1010)]
 // BIT n,REG
 fn test_bit_reg(
     #[values(


### PR DESCRIPTION
The rgbds entry says:
![image](https://github.com/user-attachments/assets/4ac2e1e6-a873-42e4-9ba7-c1e2c7b473cb)
which I interpreted as "only mutates the Z flag if the result is 0". But it actually always sets (or resets) the zero flag (see [sameboy](https://github.com/LIJI32/SameBoy/blob/64cf389edfc331e615a9571c1682f96551a5b5b8/Core/sm83_cpu.c#L1523)). This fixes the start button not doing anything in Tetris.