### PR TITLE
Fix BIT instructions zero flag behavior

### DIFF
--- a/fpt-egui/src/main.rs
+++ b/fpt-egui/src/main.rs
@@ -281,10 +281,7 @@ impl FPT {
             let cpu = self.gb.cpu();
             ui.vertical(|ui| {
                 Grid::new("cpu_registers_a-e").num_columns(4).min_col_width(10.0).striped(true).show(ui, |ui| {
-                    ui.colored_label(Color32::LIGHT_BLUE, "A");
-                    ui.monospace(format!("{:08b}", cpu.a()));
-                    ui.code(format!("{:#04X}", cpu.a()));
-                    ui.end_row();
+                    cpu_register!(ui, "A": cpu.a(), "F": cpu.f()); ui.end_row();
                     cpu_register!(ui, "B": cpu.b(), "C": cpu.c()); ui.end_row();
                     cpu_register!(ui, "D": cpu.d(), "E": cpu.e()); ui.end_row();
                     cpu_register!(ui, "H": cpu.a(), "L": cpu.f()); ui.end_row();
@@ -293,15 +290,14 @@ impl FPT {
             ui.separator();
             ui.vertical(|ui| {
                 Grid::new("flags").num_columns(1).min_col_width(10.0).striped(true).show(ui, |ui| {
-                    ui.colored_label(Color32::LIGHT_BLUE, "Z");
-                    ui.code(if cpu.z_flag() { "1" } else { "0" });
-                    ui.colored_label(Color32::LIGHT_BLUE, "N");
-                    ui.code(if cpu.n_flag() { "1" } else { "0" });
-                    ui.end_row();
-                    ui.colored_label(Color32::LIGHT_BLUE, "H");
-                    ui.code(if cpu.h_flag() { "1" } else { "0" });
                     ui.colored_label(Color32::LIGHT_BLUE, "C");
                     ui.code(if cpu.c_flag() { "1" } else { "0" });
+                    ui.colored_label(Color32::LIGHT_BLUE, "H");
+                    ui.code(if cpu.h_flag() { "1" } else { "0" });
+                    ui.colored_label(Color32::LIGHT_BLUE, "N");
+                    ui.code(if cpu.n_flag() { "1" } else { "0" });
+                    ui.colored_label(Color32::LIGHT_BLUE, "Z");
+                    ui.code(if cpu.z_flag() { "1" } else { "0" });
                 });
                 ui.horizontal(|ui| {
                     ui.colored_label(Color32::LIGHT_BLUE, "SP");

--- a/fpt/build.rs
+++ b/fpt/build.rs
@@ -39,7 +39,7 @@ fn write_test(test_file: &mut File, directory: &str) {
         if test.enabled.is_some() && !test.enabled.unwrap() {
             continue;
         }
-        let test_name = format!("{}_{}", suite.name, test.id);
+        let test_name = format!("{}_{:04}", suite.name, test.id);
 
         write!(
             test_file,

--- a/fpt/src/lr35902.rs
+++ b/fpt/src/lr35902.rs
@@ -607,9 +607,7 @@ impl LR35902 {
     }
 
     fn bit<const INDEX: u8>(&mut self, x: u8) {
-        if !bw::test_bit8::<INDEX>(x) {
-            self.set_z_flag(true);
-        }
+        self.set_z_flag(!bw::test_bit8::<INDEX>(x));
         self.set_n_flag(false);
         self.set_h_flag(true);
     }

--- a/fpt/tests/lr35902.rs
+++ b/fpt/tests/lr35902.rs
@@ -1435,7 +1435,9 @@ fn test_rot_reg_addr(
 
 #[rstest]
 #[case::not_zero(0x1, 0b0001, 0b0011)]
+#[case::not_zero(0x1, 0b1001, 0b0011)]
 #[case::zero(0x0, 0b0000, 0b1010)]
+#[case::zero(0x0, 0b1000, 0b1010)]
 // BIT n,REG
 fn test_bit_reg(
     #[values(

--- a/fpt/tests/rom_tests.json
+++ b/fpt/tests/rom_tests.json
@@ -1,337 +1,391 @@
 {
-   "name":"rom_tests",
-   "tests":[
-      {
-         "id":0,
-         "path":"../target/test_roms/mooneye/acceptance/timer/tim00.gb",
-         "termination_address":"0x4ab4"
-      },
-      {
-         "id":1,
-         "path":"../target/test_roms/mooneye/acceptance/timer/tim01.gb",
-         "termination_address":"0x4ab4"
-      },
-      {
-         "id":2,
-         "path":"../target/test_roms/mooneye/acceptance/timer/div_write.gb",
-         "termination_address":"0x4ab4"
-      },
-      {
-         "id":3,
-         "path":"../target/test_roms/mooneye/acceptance/timer/rapid_toggle.gb",
-         "termination_address":"0x4ab4",
-         "passing":false
-      },
-      {
-         "id":4,
-         "path":"../target/test_roms/mooneye/acceptance/timer/tim00_div_trigger.gb",
-         "termination_address":"0x4ab4"
-      },
-      {
-         "id":5,
-         "path":"../target/test_roms/mooneye/acceptance/timer/tim01_div_trigger.gb",
-         "termination_address":"0x4ab4"
-      },
-      {
-         "id":6,
-         "path":"../target/test_roms/mooneye/acceptance/timer/tim10_div_trigger.gb",
-         "termination_address":"0x4ab4"
-      },
-      {
-         "id":7,
-         "path":"../target/test_roms/mooneye/acceptance/timer/tim10.gb",
-         "termination_address":"0x4ab4"
-      },
-      {
-         "id":8,
-         "path":"../target/test_roms/mooneye/acceptance/timer/tim11_div_trigger.gb",
-         "termination_address":"0x4ab4"
-      },
-      {
-         "id":9,
-         "path":"../target/test_roms/mooneye/acceptance/timer/tim11.gb",
-         "termination_address":"0x4ab4"
-      },
-      {
-         "id":10,
-         "path":"../target/test_roms/mooneye/acceptance/timer/tima_reload.gb",
-         "termination_address":"0x4ab4"
-      },
-      {
-         "id":11,
-         "path":"../target/test_roms/mooneye/acceptance/timer/tima_write_reloading.gb",
-         "termination_address":"0x4ab4"
-      },
-      {
-         "id":12,
-         "path":"../target/test_roms/mooneye/acceptance/timer/tma_write_reloading.gb",
-         "termination_address":"0x4ab4"
-      },
-      {
-         "id":13,
-         "path":"../target/test_roms/mooneye/acceptance/bits/mem_oam.gb",
-         "termination_address":"0x4ab4"
-      },
-      {
-         "id":14,
-         "path":"../target/test_roms/mooneye/acceptance/bits/reg_f.gb",
-         "termination_address":"0x4ab4"
-      },
-      {
-         "id":15,
-         "path":"../target/test_roms/mooneye/acceptance/bits/unused_hwio-GS.gb",
-         "termination_address":"0x4ab4",
-         "passing":false
-      },
-      {
-         "id":16,
-         "path":"../target/test_roms/mooneye/acceptance/instr/daa.gb",
-         "termination_address":"0x4ab4",
-         "passing":false,
-         "enabled":false
-      },
-      {
-         "id":17,
-         "path":"../target/test_roms/mooneye/acceptance/interrupts/ie_push.gb",
-         "termination_address":"0x4ab4",
-         "passing":false,
-         "enabled":false
-      },
-      {
-         "id":18,
-         "path":"../target/test_roms/mooneye/acceptance/add_sp_e_timing.gb",
-         "termination_address":"0x4ab4",
-         "passing":false,
-         "enabled":false
-      },
-      {
-         "id":19,
-         "path":"../target/test_roms/mooneye/acceptance/boot_div2-S.gb",
-         "termination_address":"0x4ab4"
-      },
-      {
-         "id":20,
-         "path":"../target/test_roms/mooneye/acceptance/boot_div-dmg0.gb",
-         "termination_address":"0x4ab4"
-      },
-      {
-         "id":21,
-         "path":"../target/test_roms/mooneye/acceptance/boot_div-dmgABCmgb.gb",
-         "termination_address":"0x4ab4"
-      },
-      {
-         "id":22,
-         "path":"../target/test_roms/mooneye/acceptance/boot_div-S.gb",
-         "termination_address":"0x4ab4"
-      },
-      {
-         "id":23,
-         "path":"../target/test_roms/mooneye/acceptance/boot_hwio-dmg0.gb",
-         "termination_address":"0x4ab4",
-         "passing": false
-      },
-      {
-         "id":24,
-         "path":"../target/test_roms/mooneye/acceptance/boot_hwio-dmgABCmgb.gb",
-         "termination_address":"0x4ab4",
-         "passing": false
-      },
-      {
-         "id":25,
-         "path":"../target/test_roms/mooneye/acceptance/boot_hwio-S.gb",
-         "termination_address":"0x4ab4",
-         "passing": false
-      },
-      {
-         "id":26,
-         "path":"../target/test_roms/mooneye/acceptance/boot_regs-dmg0.gb",
-         "termination_address":"0x4ab4"
-      },
-      {
-         "id":27,
-         "path":"../target/test_roms/mooneye/acceptance/boot_regs-dmgABC.gb",
-         "termination_address":"0x4ab4"
-      },
-      {
-         "id":28,
-         "path":"../target/test_roms/mooneye/acceptance/boot_regs-mgb.gb",
-         "termination_address":"0x4ab4"
-      },
-      {
-         "id":29,
-         "path":"../target/test_roms/mooneye/acceptance/boot_regs-sgb2.gb",
-         "termination_address":"0x4ab4"
-      },
-      {
-         "id":30,
-         "path":"../target/test_roms/mooneye/acceptance/boot_regs-sgb.gb",
-         "termination_address":"0x4ab4"
-      },
-      {
-         "id":31,
-         "path":"../target/test_roms/mooneye/acceptance/call_cc_timing2.gb",
-         "termination_address":"0x4ab4"
-      },
-      {
-         "id":32,
-         "path":"../target/test_roms/mooneye/acceptance/call_cc_timing.gb",
-         "termination_address":"0x4ab4",
-         "passing": false
-      },
-      {
-         "id":34,
-         "path":"../target/test_roms/mooneye/acceptance/call_timing2.gb",
-         "termination_address":"0x4ab4"
-      },
-      {
-         "id":35,
-         "path":"../target/test_roms/mooneye/acceptance/call_timing.gb",
-         "termination_address":"0x4ab4",
-         "passing": false
-      },
-      {
-         "id":36,
-         "path":"../target/test_roms/mooneye/acceptance/di_timing-GS.gb",
-         "termination_address":"0x4ab4",
-         "passing": false,
-         "enabled": false
-      },
-      {
-         "id":37,
-         "path":"../target/test_roms/mooneye/acceptance/div_timing.gb",
-         "termination_address":"0x4ab4"
-      },
-      {
-         "id":38,
-         "path":"../target/test_roms/mooneye/acceptance/ei_sequence.gb",
-         "termination_address":"0x4ab4",
-         "passing": false,
-         "enabled": false
-      },
-      {
-         "id":39,
-         "path":"../target/test_roms/mooneye/acceptance/ei_timing.gb",
-         "termination_address":"0x4ab4",
-         "passing": false,
-         "enabled": false
-      },
-      {
-         "id":40,
-         "path":"../target/test_roms/mooneye/acceptance/halt_ime0_ei.gb",
-         "termination_address":"0x4ab4",
-         "passing": false,
-         "enabled": false
-      },
-      {
-         "id":41,
-         "path":"../target/test_roms/mooneye/acceptance/halt_ime0_nointr_timing.gb",
-         "termination_address":"0x4ab4",
-         "passing": false,
-         "enabled": false
-      },
-      {
-         "id":42,
-         "path":"../target/test_roms/mooneye/acceptance/halt_ime1_timing2-GS.gb",
-         "termination_address":"0x4ab4",
-         "passing": false,
-         "enabled": false
-      },
-      {
-         "id":43,
-         "path":"../target/test_roms/mooneye/acceptance/halt_ime1_timing.gb",
-         "termination_address":"0x4ab4",
-         "passing": false,
-         "enabled": false
-      },
-      {
-         "id":44,
-         "path":"../target/test_roms/mooneye/acceptance/if_ie_registers.gb",
-         "termination_address":"0x4ab4"
-      },
-      {
-         "id":45,
-         "path":"../target/test_roms/mooneye/acceptance/intr_timing.gb",
-         "termination_address":"0x4ab4"
-      },
-      {
-         "id":46,
-         "path":"../target/test_roms/mooneye/acceptance/jp_cc_timing.gb",
-         "termination_address":"0x4ab4",
-         "passing": false
-      },
-      {
-         "id":47,
-         "path":"../target/test_roms/mooneye/acceptance/jp_timing.gb",
-         "termination_address":"0x4ab4",
-         "passing": false
-      },
-      {
-         "id":48,
-         "path":"../target/test_roms/mooneye/acceptance/ld_hl_sp_e_timing.gb",
-         "termination_address":"0x4ab4",
-         "passing": false,
-         "enabled": false
-      },
-      {
-         "id":49,
-         "path":"../target/test_roms/mooneye/acceptance/oam_dma_restart.gb",
-         "termination_address":"0x4ab4"
-      },
-      {
-         "id":50,
-         "path":"../target/test_roms/mooneye/acceptance/oam_dma_start.gb",
-         "termination_address":"0x4ab4",
-         "passing": false,
-         "enabled": false
-      },
-      {
-         "id":51,
-         "path":"../target/test_roms/mooneye/acceptance/oam_dma_timing.gb",
-         "termination_address":"0x4ab4"
-      },
-      {
-         "id":52,
-         "path":"../target/test_roms/mooneye/acceptance/pop_timing.gb",
-         "termination_address":"0x4ab4"
-      },
-      {
-         "id":53,
-         "path":"../target/test_roms/mooneye/acceptance/push_timing.gb",
-         "termination_address":"0x4ab4"
-      },
-      {
-         "id":54,
-         "path":"../target/test_roms/mooneye/acceptance/rapid_di_ei.gb",
-         "termination_address":"0x4ab4",
-         "passing": false,
-         "enabled": false
-      },
-      {
-         "id":55,
-         "path":"../target/test_roms/mooneye/acceptance/ret_cc_timing.gb",
-         "termination_address":"0x4ab4"
-      },
-      {
-         "id":56,
-         "path":"../target/test_roms/mooneye/acceptance/reti_intr_timing.gb",
-         "termination_address":"0x4ab4",
-         "passing": false,
-         "enabled": false
-      },
-      {
-         "id":57,
-         "path":"../target/test_roms/mooneye/acceptance/reti_timing.gb",
-         "termination_address":"0x4ab4"
-      },
-      {
-         "id":58,
-         "path":"../target/test_roms/mooneye/acceptance/ret_timing.gb",
-         "termination_address":"0x4ab4"
-      },
-      {
-         "id":59,
-         "path":"../target/test_roms/mooneye/acceptance/rst_timing.gb",
-         "termination_address":"0x4ab4"
-      }
-   ]
+  "name": "rom_tests",
+  "tests": [
+    {
+      "id": 0,
+      "path": "../target/test_roms/mooneye/acceptance/timer/tim00.gb",
+      "termination_address": "0x4ab4",
+      "passing": false,
+      "enabled": false
+    },
+    {
+      "id": 1,
+      "path": "../target/test_roms/mooneye/acceptance/timer/tim01.gb",
+      "termination_address": "0x4ab4"
+    },
+    {
+      "id": 2,
+      "path": "../target/test_roms/mooneye/acceptance/timer/div_write.gb",
+      "termination_address": "0x4ab4"
+    },
+    {
+      "id": 3,
+      "path": "../target/test_roms/mooneye/acceptance/timer/rapid_toggle.gb",
+      "termination_address": "0x4ab4",
+      "passing": false
+    },
+    {
+      "id": 4,
+      "path": "../target/test_roms/mooneye/acceptance/timer/tim00_div_trigger.gb",
+      "termination_address": "0x4ab4",
+      "passing": false,
+      "enabled": false
+    },
+    {
+      "id": 5,
+      "path": "../target/test_roms/mooneye/acceptance/timer/tim01_div_trigger.gb",
+      "termination_address": "0x4ab4",
+      "passing": false,
+      "enabled": false
+    },
+    {
+      "id": 6,
+      "path": "../target/test_roms/mooneye/acceptance/timer/tim10_div_trigger.gb",
+      "termination_address": "0x4ab4",
+      "passing": false,
+      "enabled": false
+    },
+    {
+      "id": 7,
+      "path": "../target/test_roms/mooneye/acceptance/timer/tim10.gb",
+      "termination_address": "0x4ab4"
+    },
+    {
+      "id": 8,
+      "path": "../target/test_roms/mooneye/acceptance/timer/tim11_div_trigger.gb",
+      "termination_address": "0x4ab4",
+      "passing": false,
+      "enabled": false
+    },
+    {
+      "id": 9,
+      "path": "../target/test_roms/mooneye/acceptance/timer/tim11.gb",
+      "termination_address": "0x4ab4"
+    },
+    {
+      "id": 10,
+      "path": "../target/test_roms/mooneye/acceptance/timer/tima_reload.gb",
+      "termination_address": "0x4ab4",
+      "passing": false,
+      "enabled": false
+    },
+    {
+      "id": 11,
+      "path": "../target/test_roms/mooneye/acceptance/timer/tima_write_reloading.gb",
+      "termination_address": "0x4ab4",
+      "passing": false,
+      "enabled": false
+    },
+    {
+      "id": 12,
+      "path": "../target/test_roms/mooneye/acceptance/timer/tma_write_reloading.gb",
+      "termination_address": "0x4ab4",
+      "passing": false,
+      "enabled": false
+    },
+    {
+      "id": 13,
+      "path": "../target/test_roms/mooneye/acceptance/bits/mem_oam.gb",
+      "termination_address": "0x4ab4"
+    },
+    {
+      "id": 14,
+      "path": "../target/test_roms/mooneye/acceptance/bits/reg_f.gb",
+      "termination_address": "0x4ab4",
+      "passing": false,
+      "enabled": false
+    },
+    {
+      "id": 15,
+      "path": "../target/test_roms/mooneye/acceptance/bits/unused_hwio-GS.gb",
+      "termination_address": "0x4ab4",
+      "passing": false
+    },
+    {
+      "id": 16,
+      "path": "../target/test_roms/mooneye/acceptance/instr/daa.gb",
+      "termination_address": "0x4ab4",
+      "passing": false,
+      "enabled": false
+    },
+    {
+      "id": 17,
+      "path": "../target/test_roms/mooneye/acceptance/interrupts/ie_push.gb",
+      "termination_address": "0x4ab4",
+      "passing": false,
+      "enabled": false
+    },
+    {
+      "id": 18,
+      "path": "../target/test_roms/mooneye/acceptance/add_sp_e_timing.gb",
+      "termination_address": "0x4ab4",
+      "passing": false,
+      "enabled": false
+    },
+    {
+      "id": 19,
+      "path": "../target/test_roms/mooneye/acceptance/boot_div2-S.gb",
+      "termination_address": "0x4ab4",
+      "passing": false,
+      "enabled": false
+    },
+    {
+      "id": 20,
+      "path": "../target/test_roms/mooneye/acceptance/boot_div-dmg0.gb",
+      "termination_address": "0x4ab4",
+      "passing": false,
+      "enabled": false
+    },
+    {
+      "id": 21,
+      "path": "../target/test_roms/mooneye/acceptance/boot_div-dmgABCmgb.gb",
+      "termination_address": "0x4ab4",
+      "passing": false,
+      "enabled": false
+    },
+    {
+      "id": 22,
+      "path": "../target/test_roms/mooneye/acceptance/boot_div-S.gb",
+      "termination_address": "0x4ab4",
+      "passing": false,
+      "enabled": false
+    },
+    {
+      "id": 23,
+      "path": "../target/test_roms/mooneye/acceptance/boot_hwio-dmg0.gb",
+      "termination_address": "0x4ab4",
+      "passing": false
+    },
+    {
+      "id": 24,
+      "path": "../target/test_roms/mooneye/acceptance/boot_hwio-dmgABCmgb.gb",
+      "termination_address": "0x4ab4",
+      "passing": false
+    },
+    {
+      "id": 25,
+      "path": "../target/test_roms/mooneye/acceptance/boot_hwio-S.gb",
+      "termination_address": "0x4ab4",
+      "passing": false
+    },
+    {
+      "id": 26,
+      "path": "../target/test_roms/mooneye/acceptance/boot_regs-dmg0.gb",
+      "termination_address": "0x4ab4"
+    },
+    {
+      "id": 27,
+      "path": "../target/test_roms/mooneye/acceptance/boot_regs-dmgABC.gb",
+      "termination_address": "0x4ab4",
+      "passing": false,
+      "enabled": false
+    },
+    {
+      "id": 28,
+      "path": "../target/test_roms/mooneye/acceptance/boot_regs-mgb.gb",
+      "termination_address": "0x4ab4",
+      "passing": false,
+      "enabled": false
+    },
+    {
+      "id": 29,
+      "path": "../target/test_roms/mooneye/acceptance/boot_regs-sgb2.gb",
+      "termination_address": "0x4ab4",
+      "passing": false,
+      "enabled": false
+    },
+    {
+      "id": 30,
+      "path": "../target/test_roms/mooneye/acceptance/boot_regs-sgb.gb",
+      "termination_address": "0x4ab4",
+      "passing": false,
+      "enabled": false
+    },
+    {
+      "id": 31,
+      "path": "../target/test_roms/mooneye/acceptance/call_cc_timing2.gb",
+      "termination_address": "0x4ab4",
+      "passing": false,
+      "enabled": false
+    },
+    {
+      "id": 32,
+      "path": "../target/test_roms/mooneye/acceptance/call_cc_timing.gb",
+      "termination_address": "0x4ab4",
+      "passing": false
+    },
+    {
+      "id": 34,
+      "path": "../target/test_roms/mooneye/acceptance/call_timing2.gb",
+      "termination_address": "0x4ab4",
+      "passing": false,
+      "enabled": false
+    },
+    {
+      "id": 35,
+      "path": "../target/test_roms/mooneye/acceptance/call_timing.gb",
+      "termination_address": "0x4ab4",
+      "passing": false
+    },
+    {
+      "id": 36,
+      "path": "../target/test_roms/mooneye/acceptance/di_timing-GS.gb",
+      "termination_address": "0x4ab4",
+      "passing": false,
+      "enabled": false
+    },
+    {
+      "id": 37,
+      "path": "../target/test_roms/mooneye/acceptance/div_timing.gb",
+      "termination_address": "0x4ab4",
+      "passing": false,
+      "enabled": false
+    },
+    {
+      "id": 38,
+      "path": "../target/test_roms/mooneye/acceptance/ei_sequence.gb",
+      "termination_address": "0x4ab4",
+      "passing": false,
+      "enabled": false
+    },
+    {
+      "id": 39,
+      "path": "../target/test_roms/mooneye/acceptance/ei_timing.gb",
+      "termination_address": "0x4ab4",
+      "passing": false,
+      "enabled": false
+    },
+    {
+      "id": 40,
+      "path": "../target/test_roms/mooneye/acceptance/halt_ime0_ei.gb",
+      "termination_address": "0x4ab4",
+      "passing": false,
+      "enabled": false
+    },
+    {
+      "id": 41,
+      "path": "../target/test_roms/mooneye/acceptance/halt_ime0_nointr_timing.gb",
+      "termination_address": "0x4ab4",
+      "passing": false,
+      "enabled": false
+    },
+    {
+      "id": 42,
+      "path": "../target/test_roms/mooneye/acceptance/halt_ime1_timing2-GS.gb",
+      "termination_address": "0x4ab4",
+      "passing": false,
+      "enabled": false
+    },
+    {
+      "id": 43,
+      "path": "../target/test_roms/mooneye/acceptance/halt_ime1_timing.gb",
+      "termination_address": "0x4ab4",
+      "passing": false,
+      "enabled": false
+    },
+    {
+      "id": 44,
+      "path": "../target/test_roms/mooneye/acceptance/if_ie_registers.gb",
+      "termination_address": "0x4ab4",
+      "passing": false,
+      "enabled": false
+    },
+    {
+      "id": 45,
+      "path": "../target/test_roms/mooneye/acceptance/intr_timing.gb",
+      "termination_address": "0x4ab4",
+      "passing": false,
+      "enabled": false
+    },
+    {
+      "id": 46,
+      "path": "../target/test_roms/mooneye/acceptance/jp_cc_timing.gb",
+      "termination_address": "0x4ab4",
+      "passing": false
+    },
+    {
+      "id": 47,
+      "path": "../target/test_roms/mooneye/acceptance/jp_timing.gb",
+      "termination_address": "0x4ab4",
+      "passing": false
+    },
+    {
+      "id": 48,
+      "path": "../target/test_roms/mooneye/acceptance/ld_hl_sp_e_timing.gb",
+      "termination_address": "0x4ab4",
+      "passing": false,
+      "enabled": false
+    },
+    {
+      "id": 49,
+      "path": "../target/test_roms/mooneye/acceptance/oam_dma_restart.gb",
+      "termination_address": "0x4ab4",
+      "passing": false,
+      "enabled": false
+    },
+    {
+      "id": 50,
+      "path": "../target/test_roms/mooneye/acceptance/oam_dma_start.gb",
+      "termination_address": "0x4ab4",
+      "passing": false,
+      "enabled": false
+    },
+    {
+      "id": 51,
+      "path": "../target/test_roms/mooneye/acceptance/oam_dma_timing.gb",
+      "termination_address": "0x4ab4",
+      "passing": false,
+      "enabled": false
+    },
+    {
+      "id": 52,
+      "path": "../target/test_roms/mooneye/acceptance/pop_timing.gb",
+      "termination_address": "0x4ab4",
+      "passing": false,
+      "enabled": false
+    },
+    {
+      "id": 53,
+      "path": "../target/test_roms/mooneye/acceptance/push_timing.gb",
+      "termination_address": "0x4ab4",
+      "passing": false,
+      "enabled": false
+    },
+    {
+      "id": 54,
+      "path": "../target/test_roms/mooneye/acceptance/rapid_di_ei.gb",
+      "termination_address": "0x4ab4",
+      "passing": false,
+      "enabled": false
+    },
+    {
+      "id": 55,
+      "path": "../target/test_roms/mooneye/acceptance/ret_cc_timing.gb",
+      "termination_address": "0x4ab4"
+    },
+    {
+      "id": 56,
+      "path": "../target/test_roms/mooneye/acceptance/reti_intr_timing.gb",
+      "termination_address": "0x4ab4",
+      "passing": false,
+      "enabled": false
+    },
+    {
+      "id": 57,
+      "path": "../target/test_roms/mooneye/acceptance/reti_timing.gb",
+      "termination_address": "0x4ab4"
+    },
+    {
+      "id": 58,
+      "path": "../target/test_roms/mooneye/acceptance/ret_timing.gb",
+      "termination_address": "0x4ab4"
+    },
+    {
+      "id": 59,
+      "path": "../target/test_roms/mooneye/acceptance/rst_timing.gb",
+      "termination_address": "0x4ab4",
+      "passing": false,
+      "enabled": false
+    }
+  ]
 }


### PR DESCRIPTION
The rgbds entry says:
![image](https://github.com/user-attachments/assets/4ac2e1e6-a873-42e4-9ba7-c1e2c7b473cb)
which I interpreted as "only mutates the Z flag if the result is 0". But it actually always sets (or resets) the zero flag (see [sameboy](https://github.com/LIJI32/SameBoy/blob/64cf389edfc331e615a9571c1682f96551a5b5b8/Core/sm83_cpu.c#L1523)). This fixes the start button not doing anything in Tetris.