### PR TITLE
Upload v0.1 demo recording to GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FPT - Gameboy emulator
 
-<a href="http://www.youtube.com/watch?feature=player_embedded&v=tbH8Rr-0o-Q" target="_blank"><img src="https://i.imgur.com/dtFd3q7.jpeg" alt="Tetris" width="600" /></a>
+https://github.com/user-attachments/assets/c9985470-3581-48ed-9436-5cc90f24025c
 
 ## GUI
 


### PR DESCRIPTION
by dragging and dropping it when editing the README.md

HEVC (AKA H.265)
probably should have been VP9

```sh
ffmpeg -hide_banner -y -i ".../Screen Recording 2024-08-21 at 21.53.20.mov" -c:v libx265 -crf 32 -vf "scale=w=trunc(iw/2/hsub)*hsub:h=trunc(ih/2/vsub)*vsub:flags=lanczos" -sws_flags lanczos -an -preset veryslow -tag:v hvc1 -movflags +faststart "fpt-1stRelease-tetris_03.mp4"
```